### PR TITLE
feat(analytics): track exceptions via named events

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,5 @@
 setlocal wildignore+=dist,coverage,build
+setlocal foldlevelstart=2
 
 " Syntastic options
 let g:syntastic_html_tidy_ignore_errors = [

--- a/app/scripts/decorators/exceptionhandler-decorator.js
+++ b/app/scripts/decorators/exceptionhandler-decorator.js
@@ -7,7 +7,9 @@ angular.module('lmisChromeApp')
       return function(exception, cause) {
         $delegate(exception, cause);
         trackingService = trackingService || $injector.get('trackingService');
-        trackingService.trackException(exception.message, false);
+        trackingService.trackEvent(
+          'Exception', exception.message, exception.stack
+        );
       };
     });
   });

--- a/app/scripts/services/tracking-service.js
+++ b/app/scripts/services/tracking-service.js
@@ -8,11 +8,13 @@ angular.module('lmisChromeApp')
       function trackView(event, state) {
         $window.analytics.trackView(state.name);
       }
-      function trackException(event, state) {
-        $window.analytics.trackException(state.to, false);
+      function trackStateNotFound(event, unfoundState, fromState) {
+        $window.analytics.trackEvent(
+          'stateNotFound', unfoundState.to, fromState
+        );
       }
       $rootScope.$on('$stateChangeSuccess', trackView);
-      $rootScope.$on('$stateNotFound', trackException);
+      $rootScope.$on('$stateNotFound', trackStateNotFound);
     }
 
     function setUserID() {
@@ -35,13 +37,11 @@ angular.module('lmisChromeApp')
     }
 
     this.trackEvent = angular.noop;
-    this.trackException = angular.noop;
 
     if ($window.analytics) {
       $window.analytics.startTrackerWithId(config.analytics.propertyID);
       registerListeners();
       setUserID();
       self.trackEvent = $window.analytics.trackEvent;
-      self.trackException = $window.analytics.trackException;
     }
   });


### PR DESCRIPTION
Use Google Analytic's generic `trackEvent` method with custom category
names so that we can glean the full stack trace, rather than being
restricted to `trackException`s 100 character string description.

Similarly, do the same with `stateNotFound` to capture the `fromState`.

Closes #73.